### PR TITLE
Improve the way variation options are generated

### DIFF
--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -37,11 +37,18 @@ class VariationForm extends AddProductForm
 
         if (self::$include_json) {
             $vararray = array();
-
-            if ($vars = $product->Variations()) {
-                foreach ($vars as $var) {
-                    $vararray[$var->ID] = $var->AttributeValues()->map('ID', 'ID')->toArray();
-                }
+            
+            $query = $query2 = new SQLQuery();
+            
+            $query->setSelect('ID')
+                ->setFrom('ProductVariation')
+                ->setWhere(array('ProductID' => $product->ID));
+                
+            foreach ($query->execute()->column('ID') as $variationID) {
+                $query2->setSelect('ProductAttributeValueID')
+                    ->setFrom('ProductVariation_AttributeValues')
+                    ->setWhere(array('ProductVariationID' => $variationID));
+                $vararray[$variationID] = $query2->execute()->keyedColumn();
             }
 
             $fields->push(


### PR DESCRIPTION
Page load is exponentially slowed on products with multiple attribute types due to the hidden input field that's generated by Variation Form. This fix has reduced the script execution time up to this point by over 50% on my local tests and reduces further as the number of product variations increases.
